### PR TITLE
Diff panics when no changes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -327,6 +327,11 @@ impl Fastmod {
 
         let num_prefix_lines = diffs.iter().take_while(is_same).count();
         let num_suffix_lines = diffs.iter().rev().take_while(is_same).count();
+
+        if diffs.len() == num_prefix_lines {
+            return vec![];
+        }
+
         let size_of_diff = diffs.len() - num_prefix_lines - num_suffix_lines;
         let size_of_context = lines_to_print.saturating_sub(size_of_diff);
         let size_of_up_context = size_of_context / 2;
@@ -753,6 +758,13 @@ mod tests {
     }
 
     #[test]
+    fn test_diff_no_changes() {
+        let fm = Fastmod::new(false, false);
+        let diffs = fm.diffs_to_print("foo", "foo");
+        assert_eq!(diffs, vec![]);
+    }
+
+    #[test]
     fn test_print_changed_files() {
         let dir = TempDir::new("fastmodtest").unwrap();
         for file_num in 1..6 {
@@ -798,7 +810,8 @@ mod tests {
         }
         let regex = RegexBuilder::new("foo").multi_line(true).build().unwrap();
         let mut fm = Fastmod::new(true, false);
-        fm.present_and_apply_patches(&regex, "", &file_path, "foofoo".into()).unwrap();
+        fm.present_and_apply_patches(&regex, "", &file_path, "foofoo".into())
+            .unwrap();
         let mut f1 = File::open(file_path).unwrap();
         let mut contents = String::new();
         f1.read_to_string(&mut contents).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -334,6 +334,9 @@ impl Fastmod {
         let num_prefix_lines = diffs.iter().take_while(is_same).count();
         let num_suffix_lines = diffs.iter().rev().take_while(is_same).count();
 
+        // If the prefix is the length of the diff then the file matched <regex>
+        // but applying <subst> didn't result in any changes, there are no diffs
+        // to print so we return an empty Vec.
         if diffs.len() == num_prefix_lines {
             return vec![];
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,7 +280,10 @@ impl Fastmod {
         } else {
             println!("{}:{}-{}", path.to_string_lossy(), start_line, end_line);
         }
-        self.print_diff(old, new);
+        if !self.print_diff(old, new) {
+            println!("No changes.");
+            return Ok(());
+        }
         let mut user_input = if self.yes_to_all {
             'y'
         } else {
@@ -359,8 +362,11 @@ impl Fastmod {
         diffs
     }
 
-    fn print_diff(&mut self, orig: &str, edit: &str) {
+    fn print_diff(&mut self, orig: &str, edit: &str) -> bool {
+        let mut printed_diffs = false;
+
         for diff in self.diffs_to_print(orig, edit) {
+            printed_diffs = true;
             match diff {
                 DiffResult::Left(l) => {
                     self.term.fg(term::color::RED);
@@ -375,6 +381,8 @@ impl Fastmod {
                 }
             }
         }
+
+        printed_diffs
     }
 
     fn run_interactive(

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,7 +365,7 @@ impl Fastmod {
         diffs
     }
 
-    fn print_diff<'a>(&mut self, diffs: &Vec<DiffResult<&'a str>>) {
+    fn print_diff<'a>(&mut self, diffs: &[DiffResult<&'a str>]) {
         for diff in diffs {
             match diff {
                 &DiffResult::Left(l) => {


### PR DESCRIPTION
If a file matches the regex but the substitution doesn't result in a diff fastmod panics.

This makes `diffs_to_print` return an empty vec if there are no diffs to print and makes `print_diff` return a bool indicating if it printed anything.