### PR TITLE
Add release workflow using GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  package:
+    runs-on: '${{ matrix.os }}'
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: macOS-latest
+            target: x86_64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    steps:
+      - uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: stable
+      - uses: actions/checkout@v2
+      - name: Setup target
+        run: rustup target add ${{ matrix.target }}
+      - name: Install musl
+        run: sudo apt-get install musl-tools
+        if: contains(matrix.target, 'linux-musl')
+      - name: Build in release configuration
+        run: cargo build --target ${{ matrix.target }} ${{ matrix.flags }} --release --verbose
+      - name: Strip binary
+        run: strip 'target/${{ matrix.target }}/release/fastmod'
+        if: "!contains(matrix.target, 'windows')"
+      - uses: olegtarasov/get-tag@v1
+      - name: Build package
+        id: package
+        shell: bash
+        run: |
+          ARCHIVE_NAME="fastmod-${GITHUB_TAG_NAME}-${{ matrix.target }}"
+          if [[ '${{ matrix.target }}' == *windows* ]]; then
+            ARCHIVE_FILE="${ARCHIVE_NAME}.zip"
+            mv LICENSE LICENSE.txt
+            7z a "${ARCHIVE_FILE}" "./target/${{ matrix.target }}/release/fastmod.exe" ./README.md ./CHANGELOG.md ./LICENSE.txt
+            echo ::set-output "name=file::${ARCHIVE_FILE}"
+            echo ::set-output "name=name::${ARCHIVE_NAME}.zip"
+          else
+            ARCHIVE_FILE="/tmp/${ARCHIVE_NAME}.tar.gz"
+            mkdir "/tmp/${ARCHIVE_NAME}"
+            cp README.md CHANGELOG.md LICENSE "target/${{ matrix.target }}/release/fastmod" "/tmp/${ARCHIVE_NAME}"
+            tar -czf "${ARCHIVE_FILE}" -C /tmp/ "${ARCHIVE_NAME}"
+            echo ::set-output "name=file::${ARCHIVE_FILE}"
+            echo ::set-output "name=name::${ARCHIVE_NAME}.tar.gz"
+          fi
+      - name: Upload package
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ steps.package.outputs.file }}
+          asset_name:  ${{ steps.package.outputs.name }}
+          tag: ${{ github.ref }}
+          overwrite: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] – 2020-03-06
+
+### Added
+
+- Added a release workflow using GitHub Actions.
+


### PR DESCRIPTION
This workflow is the same as @lunaryorn's [Mdcat](https://github.com/lunaryorn/mdcat/blob/master/.github/workflows/release.yml) -- kudos to him !

It is triggered when a release is created with a tag named 'v something', e.g. v1.1.0.

You can see the results on my own fork [here](https://github.com/ngirard/fastmod/releases/tag/v0.3.2pre).

The 3 builds for Linux, MacOS and Windows run fine, but I've only tested the Linux one.

This PR also creates a CHANGELOG.md file, to be included in the released packages.