### PR TITLE
Use normal colors, not bright colors

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -27,8 +27,8 @@ pub enum Color {
 impl Color {
     pub fn to_crossterm_color(self) -> crossterm::style::Color {
         match self {
-            Color::Red => crossterm::style::Color::Red,
-            Color::Green => crossterm::style::Color::Green,
+            Color::Red => crossterm::style::Color::DarkRed,
+            Color::Green => crossterm::style::Color::DarkGreen,
         }
     }
 }


### PR DESCRIPTION
It looks like the `colorterm` library uses the `Dark*` prefix to mean
"not-bright" colors (e.g., ANSI codes like `0;31m` instead of `1;31m`).

Using the `0;` (not bright) variants will make this work with more color
schemes. For example, many color schemes (like Solarized) use the bright
colors to stash assorted shades of black and gray.

I'd prefer to change the default to the `Dark*` variants because I think
that it will work out of the box better for most people and look good.
But I'd also be open to adding a config option so that people could
write something like

```bash
alias fastmod=fastmod --color-removed=XYZ --color-added=ABC
```

Thanks!

**Before**

<img width="608" alt="Screen Shot 2021-03-02 at 1 14 46 PM" src="https://user-images.githubusercontent.com/5544532/109716569-e4734f00-7b59-11eb-9b32-45dfb3adbcf5.png">


**After**
<img width="626" alt="Screen Shot 2021-03-02 at 1 14 36 PM" src="https://user-images.githubusercontent.com/5544532/109716571-e5a47c00-7b59-11eb-9835-5f0afa0c1d5a.png">
